### PR TITLE
feat: implement VM pause and resume

### DIFF
--- a/firepilot/src/executor.rs
+++ b/firepilot/src/executor.rs
@@ -158,11 +158,16 @@ impl Executor {
     }
 
     #[instrument(skip_all, fields(id = %self.id))]
-    async fn send_request(&self, url: hyper::Uri, body: String) -> Result<(), ExecuteError> {
+    async fn send_request(
+        &self,
+        url: hyper::Uri,
+        method: Method,
+        body: String,
+    ) -> Result<(), ExecuteError> {
         debug!("Send request to socket: {}", url);
         trace!("Sent body to socket [{}]: {}", url, body);
         let request = Request::builder()
-            .method(Method::PUT)
+            .method(method)
             .uri(url.clone())
             .header("Content-Type", "application/json")
             .header("Accept", "application/json")
@@ -204,7 +209,7 @@ impl Executor {
         let json = serde_json::to_string(&action).map_err(ExecuteError::Serialize)?;
 
         let url: hyper::Uri = Uri::new(self.chroot().join("firecracker.socket"), "/actions").into();
-        self.send_request(url, json).await?;
+        self.send_request(url, Method::PUT, json).await?;
         Ok(())
     }
 
@@ -261,7 +266,7 @@ impl Executor {
 
         let url: hyper::Uri =
             Uri::new(self.chroot().join("firecracker.socket"), "/boot-source").into();
-        self.send_request(url, json).await?;
+        self.send_request(url, Method::PUT, json).await?;
         Ok(())
     }
 
@@ -276,7 +281,7 @@ impl Executor {
 
             let path = format!("/drives/{}", drive.drive_id);
             let url: hyper::Uri = Uri::new(self.chroot().join("firecracker.socket"), &path).into();
-            self.send_request(url, json).await?;
+            self.send_request(url, Method::PUT, json).await?;
         }
         Ok(())
     }
@@ -296,7 +301,7 @@ impl Executor {
 
             let path = format!("/network-interfaces/{}", network_interface.iface_id);
             let url: hyper::Uri = Uri::new(self.chroot().join("firecracker.socket"), &path).into();
-            self.send_request(url, json).await?;
+            self.send_request(url, Method::PUT, json).await?;
         }
         Ok(())
     }

--- a/firepilot/src/machine.rs
+++ b/firepilot/src/machine.rs
@@ -35,6 +35,8 @@ use crate::{
     executor::{Action, Executor},
 };
 
+use firepilot_models::models::vm::{State, Vm};
+
 #[derive(Debug)]
 pub enum FirepilotError {
     /// Mostly problems related to directories error or unavailable files
@@ -149,6 +151,18 @@ impl Machine {
     /// Send a CtrlAltDel signal so it will shutdown gracefully
     pub async fn stop(&self) -> Result<(), FirepilotError> {
         self.executor.send_action(Action::SendCtrlAltDel).await?;
+        Ok(())
+    }
+
+    /// Pause a running VM
+    pub async fn pause(&self) -> Result<(), FirepilotError> {
+        self.executor.set_vm_state(Vm::new(State::Paused)).await?;
+        Ok(())
+    }
+
+    /// Resume a paused VM
+    pub async fn resume(&self) -> Result<(), FirepilotError> {
+        self.executor.set_vm_state(Vm::new(State::Resumed)).await?;
         Ok(())
     }
 }


### PR DESCRIPTION
## 📑 Description

Implement VM pause and resume, which is needed to take snapshots, as detailed [here](/firecracker-microvm/firecracker/blob/532677328480b7f4149192ec121ac076451ac098/docs/snapshotting/snapshot-support.md#snapshot-api).

## ✅ Checks

<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->

- [x] My pull request adheres to the code style of this project
- [x] My code is documented
- [ ] I provided unitary tests or procedure to test my code
- [x] My PR have a clear description of what my code is supposed to do