### PR TITLE
feat: implement vsock configuration for VMs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,7 @@ name = "firepilot"
 version = "1.1.0"
 dependencies = [
  "doc-comment",
- "firepilot_models 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "firepilot_models",
  "hyper",
  "hyperlocal",
  "log",
@@ -161,19 +161,6 @@ dependencies = [
 [[package]]
 name = "firepilot_models"
 version = "1.3.0"
-dependencies = [
- "serde",
- "serde_derive",
- "serde_json",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "firepilot_models"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d31837f8c997263f1600fef39b579deb871538825b3dd13bbee95a539fe2658"
 dependencies = [
  "serde",
  "serde_derive",

--- a/firepilot/Cargo.toml
+++ b/firepilot/Cargo.toml
@@ -23,7 +23,7 @@ hyperlocal = "0.8"
 serde_derive = "1.0.160"
 url = "^2.2"
 tokio = { version = "1.27.0", features = ["process", "rt", "macros"], default-features = false }
-firepilot_models = "1.3.0"
+firepilot_models = { path = "../firepilot_models" }
 tracing = "0.1"
 
 [dev-dependencies]

--- a/firepilot/src/builder/mod.rs
+++ b/firepilot/src/builder/mod.rs
@@ -51,17 +51,18 @@
 //! ```
 use crate::executor::Executor;
 
-use firepilot_models::models::{BootSource, Drive, NetworkInterface};
+use firepilot_models::models::{BootSource, Drive, NetworkInterface, Vsock};
 
 pub mod drive;
 pub mod executor;
 pub mod kernel;
 pub mod network_interface;
+pub mod vsock;
 
 fn assert_not_none<T>(key: &str, value: &Option<T>) -> Result<(), BuilderError> {
     match value {
         Some(_) => Ok(()),
-        None => return Err(BuilderError::MissingRequiredField(key.to_string())),
+        None => Err(BuilderError::MissingRequiredField(key.to_string())),
     }
 }
 
@@ -102,6 +103,7 @@ pub struct Configuration {
     pub kernel: Option<BootSource>,
     pub storage: Vec<Drive>,
     pub interfaces: Vec<NetworkInterface>,
+    pub vsock: Option<Vsock>,
 
     pub vm_id: String,
 }
@@ -113,6 +115,7 @@ impl Configuration {
             executor: None,
             storage: Vec::new(),
             interfaces: Vec::new(),
+            vsock: None,
             vm_id,
         }
     }
@@ -135,6 +138,11 @@ impl Configuration {
 
     pub fn with_interface(mut self, iface: NetworkInterface) -> Configuration {
         self.interfaces.push(iface);
+        self
+    }
+
+    pub fn with_vsock(mut self, vsock: Vsock) -> Configuration {
+        self.vsock = Some(vsock);
         self
     }
 }

--- a/firepilot/src/builder/vsock.rs
+++ b/firepilot/src/builder/vsock.rs
@@ -1,0 +1,68 @@
+use crate::builder::{Builder, BuilderError};
+use firepilot_models::models::Vsock;
+
+use super::assert_not_none;
+
+#[derive(Debug)]
+pub struct VsockBuilder {
+    pub guest_cid: Option<i32>,
+    pub uds_path: Option<String>,
+}
+
+impl Default for VsockBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl VsockBuilder {
+    pub fn new() -> VsockBuilder {
+        VsockBuilder {
+            guest_cid: None,
+            uds_path: None,
+        }
+    }
+
+    pub fn with_guest_cid(mut self, guest_cid: i32) -> VsockBuilder {
+        self.guest_cid = Some(guest_cid);
+        self
+    }
+
+    pub fn with_uds_path(mut self, uds_path: String) -> VsockBuilder {
+        self.uds_path = Some(uds_path);
+        self
+    }
+}
+
+impl Builder<Vsock> for VsockBuilder {
+    fn try_build(self) -> Result<Vsock, BuilderError> {
+        assert_not_none(stringify!(self.guest_cid), &self.guest_cid)?;
+        assert_not_none(stringify!(self.uds_path), &self.uds_path)?;
+        Ok(Vsock {
+            guest_cid: self.guest_cid.unwrap(),
+            uds_path: self.uds_path.unwrap(),
+            vsock_id: None,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::builder::vsock::VsockBuilder;
+    use crate::builder::Builder;
+
+    #[test]
+    fn full_kernel() {
+        VsockBuilder::new()
+            .with_guest_cid(3)
+            .with_uds_path("/tmp/fc.sock".to_string())
+            .try_build()
+            .unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn partial_kernel() {
+        VsockBuilder::new().with_guest_cid(3).try_build().unwrap();
+    }
+}

--- a/firepilot/src/machine.rs
+++ b/firepilot/src/machine.rs
@@ -133,6 +133,10 @@ impl Machine {
         self.executor.configure_drives(config.storage).await?;
         self.executor.configure_boot_source(kernel).await?;
         self.executor.configure_network(config.interfaces).await?;
+        if let Some(vsock) = config.vsock {
+            self.executor.configure_vsock(vsock).await?;
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
## 📑 Description

Implements vsock for firecracker VMs spawned by firepilot by adding the configuration and API call to the firecracker server.

## ✅ Checks

- [X] My pull request adheres to the code style of this project
- [X] My code is documented
- [X] I provided unitary tests or procedure to test my code
- [X] My PR have a clear description of what my code is supposed to do